### PR TITLE
[do-not-merge][prototype]Simple meson build for csp_core

### DIFF
--- a/cpp/csp/core/Config.h.in
+++ b/cpp/csp/core/Config.h.in
@@ -1,10 +1,9 @@
-#cmakedefine CSP_VERSION_MAJOR
-#cmakedefine CSP_VERSION_MINOR
-#cmakedefine CSP_VERSION_PATCH
+#mesondefine CSP_VERSION_MAJOR
+#mesondefine CSP_VERSION_MINOR
+#mesondefine CSP_VERSION_PATCH
 #define CSP_VERSION ((CSP_VERSION_MAJOR * 1000) + CSP_VERSION_MINOR) * 1000 + CSP_VERSION_PATCH
 
 // in case we need this in plugins
 #define CSP_ABI_VERSION CSP_VERSION_MAJOR
 
-#cmakedefine CSP_BUILD_TYPE
-
+#mesondefine CSP_BUILD_TYPE

--- a/cpp/csp/core/README.md
+++ b/cpp/csp/core/README.md
@@ -1,0 +1,7 @@
+The core library can be built with meson by following the steps given below,
+
+1. `meson setup builddir`
+2. `cd builddir`
+3. `meson compile`
+
+Note that you need to switch your working directory to `cpp/csp/core` from project root.

--- a/cpp/csp/core/meson.build
+++ b/cpp/csp/core/meson.build
@@ -1,0 +1,7 @@
+core_public_headers = ['BasicAllocator.h', 'Config.h.in', 'DynamicBitSet.h', 'Enum.h', 'EnumBitSet.h', 'Exception.h', 'FileUtils.h', 'Generator.h', 'Hash.h', 'Likely.h', 'QueueWaiter.h', 'Platform.h', 'SRMWLockFreeQueue.h', 'System.h', 'TaggedPointerUnion.h', 'Time.h']
+core_source_files = ['Exception.cpp', 'Time.cpp', core_public_headers]
+# configure_file(['Config.h.in', cmake_current_binary_dir, '/cpp/csp/core/Config.h'])
+csp_core_lib = static_library('csp_core', core_source_files)
+# set_target_properties(['csp_core', 'PROPERTIES', 'PUBLIC_HEADER', '${CORE_PUBLIC_HEADERS}'])
+# install(['TARGETS', 'csp_core', 'PUBLIC_HEADER', 'DESTINATION', 'include/csp/core', 'RUNTIME', 'DESTINATION', csp_runtime_install_subdir, 'LIBRARY', 'DESTINATION', 'lib/'])
+# install(['FILES', cmake_current_binary_dir, '/cpp/csp/core/Config.h', 'DESTINATION', 'include/csp/core'])

--- a/cpp/csp/core/meson.build
+++ b/cpp/csp/core/meson.build
@@ -6,6 +6,7 @@ project(
   meson_version: '>= 1.1.0',
   default_options: [
     'cpp_std=c++17',
+    'default_library=static',
   ],
 )
 
@@ -43,10 +44,10 @@ core_source_files = [
     'Time.cpp'
 ]
 
-csp_core_lib = static_library(
+csp_core_lib = library(
     'csp_core',
     core_source_files,
-    include_directories: '../../../',
+    include_directories: '../../',
     install: true,
 )
 

--- a/cpp/csp/core/meson.build
+++ b/cpp/csp/core/meson.build
@@ -1,7 +1,53 @@
-core_public_headers = ['BasicAllocator.h', 'Config.h.in', 'DynamicBitSet.h', 'Enum.h', 'EnumBitSet.h', 'Exception.h', 'FileUtils.h', 'Generator.h', 'Hash.h', 'Likely.h', 'QueueWaiter.h', 'Platform.h', 'SRMWLockFreeQueue.h', 'System.h', 'TaggedPointerUnion.h', 'Time.h']
-core_source_files = ['Exception.cpp', 'Time.cpp', core_public_headers]
-# configure_file(['Config.h.in', cmake_current_binary_dir, '/cpp/csp/core/Config.h'])
-csp_core_lib = static_library('csp_core', core_source_files)
-# set_target_properties(['csp_core', 'PROPERTIES', 'PUBLIC_HEADER', '${CORE_PUBLIC_HEADERS}'])
-# install(['TARGETS', 'csp_core', 'PUBLIC_HEADER', 'DESTINATION', 'include/csp/core', 'RUNTIME', 'DESTINATION', csp_runtime_install_subdir, 'LIBRARY', 'DESTINATION', 'lib/'])
-# install(['FILES', cmake_current_binary_dir, '/cpp/csp/core/Config.h', 'DESTINATION', 'include/csp/core'])
+project(
+  'csp_core',
+  'cpp',
+  version: '0.0.4',
+  license: 'BSD-3',
+  meson_version: '>= 1.1.0',
+  default_options: [
+    'cpp_std=c++17',
+  ],
+)
+
+PROJECT_VERSION = meson.project_version().split('.')
+conf_data = configuration_data()
+conf_data.set('CSP_VERSION_MAJOR', PROJECT_VERSION[0])
+conf_data.set('CSP_VERSION_MINOR', PROJECT_VERSION[1])
+conf_data.set('CSP_VERSION_PATCH', PROJECT_VERSION[2])
+configure_file(input : 'Config.h.in',
+               output : 'Config.h',
+               configuration : conf_data)
+
+core_public_headers = [
+    'BasicAllocator.h',
+    meson.current_build_dir()/'Config.h',
+    'DynamicBitSet.h',
+    'Enum.h',
+    'EnumBitSet.h',
+    'Exception.h',
+    'FileUtils.h',
+    'Generator.h',
+    'Hash.h',
+    'Likely.h',
+    'QueueWaiter.h',
+    'Platform.h',
+    'SRMWLockFreeQueue.h',
+    'System.h',
+    'TaggedPointerUnion.h',
+    'Time.h'
+]
+
+core_source_files = [
+    core_public_headers,
+    'Exception.cpp',
+    'Time.cpp'
+]
+
+csp_core_lib = static_library(
+    'csp_core',
+    core_source_files,
+    include_directories: '../../../',
+    install: true,
+)
+
+install_headers(core_public_headers, subdir: 'csp/core')


### PR DESCRIPTION
This adds a simple `meson.build` file only for csp_core, i.e. in `cpp/csp/core/meson.build`.

This demonstrates how to build the core library with meson. The basic use is shown in the accompanying README.md.
Briefly, with meson installed (for example via `mamba install meson` into a conda environment that also contains the necessary build dependencies), it is a similar process to cmake. Side-by-side:

|meson|cmake|
|-|-|
|meson setup builddir && cd builddir|mkdir builddir && cd builddir && cmake ..|
|meson compile|make|
|meson install|make install|

Just like with cmake, meson can be influenced by the use of command-line options. For example, to set the final install directory, we can pass `--prefix=$(pwd)/target` to the `meson setup` command. We can also choose to build both static and dynamic libraries with `-Ddefault_library=both`.

Similarly, we can decide which parts to install in the `meson install` command using so-called tags.
Doing `meson install --tags=runtime` will only install the dynamic library, `meson install --tags=devel` will only install the static library together with the necessary header files.
With no tags, everything will be installed.